### PR TITLE
fix: make a more useful archive index

### DIFF
--- a/prisma/migrations/20250901224914_remove_bad_archive_index/migration.sql
+++ b/prisma/migrations/20250901224914_remove_bad_archive_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY "public"."LiveRecordingArchive_bvid_pubdate_idx";

--- a/prisma/migrations/20250901225007_add_archive_index/migration.sql
+++ b/prisma/migrations/20250901225007_add_archive_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "LiveRecordingArchive_vtuberProfileId_pubdate_idx" ON "public"."LiveRecordingArchive"("vtuberProfileId", "pubdate" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,7 +259,10 @@ model LiveRecordingArchive {
   /// The songs that were played in the live
   SongOccurrenceInLive SongOccurrenceInLive[]
 
-  @@index([bvid, pubdate(sort: Desc)])
+  /// I noticed the recording archive query was the most expensive query I saw from monitoring, try if gettinga better
+  /// index helps.
+  /// We technically always query archives from the vtuberProfileId edge and scroll through pudate with keyset pagination.
+  @@index([vtuberProfileId, pubdate(sort: Desc)])
 }
 
 /// This is the relation table between Song and LiveRecordingArchive.


### PR DESCRIPTION

```
0.1 ms | 0.7 ms | SELECT "public"."VtuberExternalLink"."id", "public"."VtuberExternalLink"."vtuberProfileId", "public"."VtuberExternalLink"."value", "public"."VtuberExternalLink"."icon", "public"."VtuberExternalLink"."href", "public"."VtuberExternalLink"."displayOrder", "public"."VtuberExternalLink"."createdOn", "public"."VtuberExternalLink"."updatedOn" FROM "public"."VtuberExternalLink" WHERE "public"."VtuberExternalLink"."vtuberProfileId" IN ($1) ORDER BY "public"."VtuberExternalLink"."displayOrder" ASC OFFSET $2
```